### PR TITLE
add rollup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,10 @@ npm install -g @vue/cli
 vue create [NAME]
 ```
 
+## Rollup
+
+The [Rollup example](./rollup/) was generated with [rollup-starter-app](https://github.com/rollup/rollup-starter-app):
+
+```
+npx degit "rollup/rollup-starter-app" [NAME]
+```

--- a/rollup/.gitignore
+++ b/rollup/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules
+package-lock.json
+public/assets/
+public/*.js
+public/*.js.map

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -1,0 +1,92 @@
+# Rollup
+
+This repo contains a bare-bones example of how to create an application using Rollup and calcite-components. It was generated with [rollup-starter-app](https://github.com/rollup/rollup-starter-lib).
+
+To get started using this project, use:
+
+```
+npm install
+npm run dev
+```
+
+This will install dependencies and then start up a development server on [localhost:5000](http://localhost:5000).
+
+## Calcite Components with Rollup
+
+To install calcite components, first run:
+
+```
+npm install --save @esri/calcite-components
+```
+
+After calcite-components is installed, import the custom elements bundle and the global CSS in your `main.js` file:
+
+```js
+import '@esri/calcite-components/dist/calcite/calcite.css';
+import { defineCustomElements, setAssetPath } from '@esri/calcite-components/dist/custom-elements';
+
+setAssetPath(document.currentScript.src);
+defineCustomElements();
+```
+
+Using `setAssetPath` will ensure that calcite components look for assets like icons in the correct location (more on copying assets below).
+
+Notice in the above code sample we aren't passing any arguments to `defineCustomElements`. This will define all of the available components. You can also import just what you need by selecting individual icons:
+
+```js
+import { CalciteButton } from '@esri/calcite-components/dist/custom-elements';
+
+customElements.define('calcite-button', CalciteButton);
+```
+
+See Stencil's [custom elements documentation](https://stenciljs.com/docs/custom-elements) for more information.
+
+## Configuring Rollup
+
+There are a few more steps we need to take so that rollup can successfully bundle our application. In addition to the basic configuration provided by rollup-starter-app, we need to:
+
+- copy over icons
+- enable importing css into our bundle
+- set the output format to `es`
+
+To that end, at the top of your config, add the following imports:
+
+```js
+import copy from 'rollup-plugin-copy';
+import postcss from 'rollup-plugin-postcss';
+import path from 'path';
+```
+
+### Set the Format to ES
+
+For the module to bundle properly you'll need to use the `es` output format. _**Note**: This will not work if you need to support legacy browsers like IE11_. To set the output format, add the following to the `output` property:
+
+```js
+output: [{ dir: path.resolve('public'), format: 'es' }],
+```
+
+### Enable CSS Import
+
+Simply add the postcss plugin to the plugins array:
+
+```js
+postcss({
+  extensions: ['.css']
+}),
+```
+
+### Copying Icons
+
+To copy the icon assets over, you can use the `rollup-plugin-copy` package, adding it the the same plugins array:
+
+```js
+copy({
+  targets: [
+    {
+      src: path.resolve(__dirname, 'node_modules/@esri/calcite-components/dist/calcite/assets'),
+      dest: path.resolve(__dirname, 'public')
+    },
+  ]
+}),
+```
+

--- a/rollup/package.json
+++ b/rollup/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rollup-starter-app",
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^11.0.1",
+    "@rollup/plugin-node-resolve": "^7.0.0",
+    "@stencil/core": "^1.17.2",
+    "npm-run-all": "^4.1.5",
+    "rollup": "^1.16.2",
+    "rollup-plugin-copy": "^3.3.0",
+    "rollup-plugin-postcss": "^3.1.3",
+    "rollup-plugin-terser": "^5.0.0",
+    "serve": "^11.0.2"
+  },
+  "dependencies": {
+    "@esri/calcite-components": "^1.0.0-beta.36"
+  },
+  "scripts": {
+    "build": "rollup -c",
+    "watch": "rollup -c -w",
+    "dev": "npm-run-all --parallel start watch",
+    "start": "serve public"
+  }
+}

--- a/rollup/public/index.html
+++ b/rollup/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head lang='en'>
+	<meta charset='utf-8'>
+	<meta name='viewport' content='width=device-width'>
+	<title>rollup-starter-app</title>
+</head>
+<body>
+	<h1>rollup-starter-app</h1>
+	<calcite-button>My Button</calcite-button>
+	<calcite-icon icon="banana"></calcite-icon>
+	<script src='main.js' ></script>
+</body>
+</html>

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -1,0 +1,31 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
+import copy from 'rollup-plugin-copy';
+import postcss from 'rollup-plugin-postcss';
+import path from 'path';
+
+// `npm run build` -> `production` is true
+// `npm run dev` -> `production` is false
+const production = !process.env.ROLLUP_WATCH;
+
+export default {
+  input: 'src/main.js',
+  output: [{ dir: path.resolve('public'), format: 'es' }],
+  plugins: [
+    resolve(), // tells Rollup how to find node_modules
+    commonjs(), // needed if you're using libraries that leverage commonjs
+    postcss({ // allows us to import the global calcite css
+      extensions: ['.css']
+    }),
+    copy({ // copy over the calcite-components assets
+      targets: [
+        {
+          src: path.resolve(__dirname, 'node_modules/@esri/calcite-components/dist/calcite/assets'),
+          dest: path.resolve(__dirname, 'public')
+        },
+      ]
+    }),
+    production && terser() // minify, but only in production
+  ]
+};

--- a/rollup/src/main.js
+++ b/rollup/src/main.js
@@ -1,0 +1,5 @@
+import '@esri/calcite-components/dist/calcite/calcite.css';
+import { defineCustomElements, setAssetPath } from '@esri/calcite-components/dist/custom-elements';
+
+setAssetPath(document.currentScript.src);
+defineCustomElements();


### PR DESCRIPTION
Adding an example of how to bundle these components into an application with [Rollup.js](https://rollupjs.org/guide/en/). Answers the question from issue https://github.com/Esri/calcite-components/issues/485 .

This is kind of neat because you can import components by name and it makes it feel a bit more like other library imports.