### PR TITLE
chore: update code for beta 49 changes

### DIFF
--- a/angular/.gitignore
+++ b/angular/.gitignore
@@ -4,7 +4,7 @@
 /dist
 /tmp
 /out-tsc
-/src/assets/*.json
+/src/assets/
 # Only exists if Bazel was run
 /bazel-out
 

--- a/angular/package.json
+++ b/angular/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "copy": "cp node_modules/@esri/calcite-components/dist/calcite/assets/*.json ./src/assets/"
+    "copy": "cp -R node_modules/@esri/calcite-components/dist/calcite/assets/ ./src/assets/"
   },
   "private": true,
   "dependencies": {
@@ -28,7 +28,7 @@
     "@angular-devkit/build-angular": "~0.901.6",
     "@angular/cli": "~9.1.6",
     "@angular/compiler-cli": "~9.1.7",
-    "@esri/calcite-components": "^1.0.0-beta.33",
+    "@esri/calcite-components": "~1.0.0-next.73",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,
+    "esModuleInterop": true,
     "experimentalDecorators": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/ember/README.md
+++ b/ember/README.md
@@ -96,7 +96,7 @@ module.exports = function(defaults) {
   // Funnel the calcite icons into the build assets directory
   const calciteIconTree = new Funnel('./node_modules/@esri/calcite-components/dist', {
     srcDir: '/',
-    include: ['calcite/assets/*.json'],
+    include: ['calcite/assets/'],
     destDir: '/assets'
   });
 
@@ -131,9 +131,9 @@ module.exports = function(defaults) {
   app.import('node_modules/@esri/calcite-components/dist/calcite/calcite.css');
 
   // Funnel the calcite icons into the build assets directory
-  const calciteIconTree = new Funnel('./node_modules/@esri/calcite-components/dist/calcite/assets', {
+  const calciteIconTree = new Funnel('./node_modules/@esri/calcite-components/dist/', {
     srcDir: '/',
-    include: ['*.json'],
+    include: ['calcite/assets/'],
     destDir: '/assets'
   });
 
@@ -167,7 +167,7 @@ module.exports = function (defaults) {
 
   trees.push(new Funnel('./node_modules/@esri/calcite-components/dist', {
     srcDir: '/',
-    include: ['calcite/assets/*.json'],
+    include: ['calcite/assets/'],
     destDir: '/assets'
   }));
 

--- a/ember/ember-cli-build.js
+++ b/ember/ember-cli-build.js
@@ -15,7 +15,7 @@ module.exports = function (defaults) {
   // Funnel the calcite icon into the build assets directory
   let calciteIconTree = new Funnel('./node_modules/@esri/calcite-components/dist', {
     srcDir: '/',
-    include: ['calcite/assets/*.json'],
+    include: ['calcite/assets/'],
     destDir: '/assets'
   });
 

--- a/ember/package.json
+++ b/ember/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
-    "@esri/calcite-components": "^1.0.0-beta.33",
+    "@esri/calcite-components": "~1.0.0-next.73",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.1.0",

--- a/preact-typescript/.gitignore
+++ b/preact-typescript/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 /build
 /*.log
-src/assets/*.json
+src/assets/

--- a/preact-typescript/package.json
+++ b/preact-typescript/package.json
@@ -8,10 +8,10 @@
     "serve": "sirv build --port 8080 --cors --single",
     "dev": "preact watch",
     "test": "jest ./tests",
-    "copy": "cp node_modules/@esri/calcite-components/dist/calcite/assets/*.json ./src/assets/"
+    "copy": "cp -R node_modules/@esri/calcite-components/dist/calcite/assets/ ./src/assets/"
   },
   "dependencies": {
-    "@esri/calcite-components": "^1.0.0-beta.32",
+    "@esri/calcite-components": "~1.0.0-next.73",
     "preact": "^10.3.1",
     "preact-jsx-chai": "^3.0.0",
     "preact-markup": "^2.0.0",

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@esri/calcite-components": "^1.0.0-beta.33",
+    "@esri/calcite-components": "~1.0.0-next.73",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -17,7 +17,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "precopy": "mkdir public/assets/",
-    "copy": "cp node_modules/@esri/calcite-components/dist/calcite/assets/*.json ./public/assets/"
+    "copy": "cp -R node_modules/@esri/calcite-components/dist/calcite/assets/ ./public/assets/"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/rollup/package.json
+++ b/rollup/package.json
@@ -12,7 +12,7 @@
     "serve": "^11.0.2"
   },
   "dependencies": {
-    "@esri/calcite-components": "^1.0.0-beta.36"
+    "@esri/calcite-components": "~1.0.0-next.73"
   },
   "scripts": {
     "build": "rollup -c",

--- a/vue/package.json
+++ b/vue/package.json
@@ -7,10 +7,10 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "precopy": "mkdir public/assets",
-    "copy": "cp node_modules/@esri/calcite-components/dist/calcite/assets/*.json ./public/assets/"
+    "copy": "cp -R node_modules/@esri/calcite-components/dist/calcite/assets/ ./public/assets/"
   },
   "dependencies": {
-    "@esri/calcite-components": "^1.0.0-beta.33",
+    "@esri/calcite-components": "~1.0.0-next.73",
     "core-js": "^3.6.4",
     "vue": "^2.6.11"
   },

--- a/web-dev-server/package.json
+++ b/web-dev-server/package.json
@@ -13,6 +13,6 @@
     "@web/dev-server": "^0.1.3"
   },
   "dependencies": {
-    "@esri/calcite-components": "^1.0.0-beta.47"
+    "@esri/calcite-components": "~1.0.0-next.73"
   }
 }

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@esri/calcite-components": "1.0.0-beta.42"
+    "@esri/calcite-components": "~1.0.0-next.73"
   },
   "devDependencies": {
     "@stencil/webpack": "0.0.6",


### PR DESCRIPTION
This PR updates how assets are copied from calcite-components as they will now be shipped a single `assets` directory.

### Notes

* The `preact-typescript` example does not work at the moment because @next versions don't ship with preact typings.
* Updated `tsconfig.json` to appease build. I'll see if we can do something on the component's side to not require this change on consumers.

### Pending

- [ ] update to beta.49 when released
- [ ] test all examples
  - [x] angular
  - [ ] ember
  - [ ] preact-typescript
  - [ ] react
  - [ ] rollup
  - [ ] vue
  - [ ] web-dev-server
  - [ ] webpack