### PR TITLE
use assets in angular config to copy angular assets

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -50,13 +50,16 @@ Calcite Components has a single stylesheet which provides CSS variables for colo
 
 ## Adding the assets
 
-There are a few static assets (calendar nls data, icon paths) that must be copied over to the assets folder manually. A `copy` script has been created to make this process easier:
+There are a few static assets (calendar nls data, icon paths) used by calcite components. You can add the following to `architect.build.options.assets` in the `angular.json` file to serve these assets directly from the calcite components library in `node_modules`:
 
-```
-npm run copy
+```json
+{
+  "glob": "**/*.json",
+  "input": "./node_modules/@esri/calcite-components/dist/calcite/assets/",
+  "output": "./assets/"
+}
 ```
 
-This will copy the JSON assets required by the icon component to your project's `assets` directory.
 
 ## Edge and IE11 polyfills
 

--- a/angular/angular.json
+++ b/angular/angular.json
@@ -21,7 +21,12 @@
             "aot": true,
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "**/*.json",
+                "input": "./node_modules/@esri/calcite-components/dist/calcite/assets/",
+                "output": "./assets/"
+              }
             ],
             "styles": [
               "src/styles.css"

--- a/angular/package.json
+++ b/angular/package.json
@@ -7,8 +7,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e",
-    "copy": "cp -r node_modules/@esri/calcite-components/dist/calcite/assets/* ./src/assets/"
+    "e2e": "ng e2e"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
I think this is a much better way to do the assets for angular projects. @macandcheese I don't know how the content of the frameworks section on the library site gets built, but we should probably update it there as well: https://developers.arcgis.com/calcite-design-system/framework-examples/angular/