### PR TITLE
chore(rollup): update config to exclude calcite-components entry file from commonjs plugin

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -13,7 +13,11 @@ export default {
   output: [{ dir: 'public', format: 'es' }],
   plugins: [
     resolve(), // tells Rollup how to find node_modules
-    commonjs(), // needed if you're using libraries that leverage commonjs
+    commonjs({
+      exclude: [
+        "node_modules/@esri/calcite-components/dist/custom-elements/index.js"
+      ]
+    }), // needed if you're using libraries that leverage commonjs
     postcss({ // allows us to import the global calcite css
       extensions: ['.css']
     }),


### PR DESCRIPTION
This PR updates the Rollup config to prevent the `commonjs` plugin from transforming `calcite-components` files.

This should also help when https://github.com/Esri/calcite-components/pull/3224 lands as it will no longer include `index.mjs` (introduced via https://github.com/Esri/calcite-components/pull/781).