### PR TITLE
docs(readme): remove polyfill and deprecated build info

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -22,22 +22,31 @@ npm install --save @esri/calcite-components
 
 To use custom components in Angular, you have to tell the module to include the schema for custom elements. Fortunately, Angular makes this pretty easy. Add something like the following to your `app.module.ts` file:
 
-```
+```ts
+// src/app/app.module.ts
 import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 
 @NgModule({
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
-To import the custom elements that make up calcite components, import their definition function from the loader, and call it. Add the following to your `main.ts` file:
+Next, import and call `setAssetPath`:
 
+```ts
+// src/main.ts
+import { setAssetPath } from "@esri/calcite-components/dist/components";
+setAssetPath(location.href);
 ```
-// import
-import { defineCustomElements } from "@esri/calcite-components/dist/loader";
-// define the elements, passing in the window
-defineCustomElements(window);
+
+Now that everything is set up, you can import the components:
+
+```ts
+// src/app/app.component.ts
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-date-picker";
 ```
 
 ## Adding the CSS
@@ -59,17 +68,3 @@ There are a few static assets (calendar nls data, icon paths) used by calcite co
   "output": "./assets/"
 }
 ```
-
-
-## Edge and IE11 polyfills
-
-For IE11 and Edge support, you'll need to call the `applyPolyfills()` method prior to defining the elements:
-
-```
-import { applyPolyfills, defineCustomElements } from "@esri/calcite-components/dist/loader";
-// ...
-applyPolyfills().then(() => {
-  defineCustomElements(window)
-})
-```
-

--- a/ember/README.md
+++ b/ember/README.md
@@ -51,26 +51,19 @@ The best place to define the calcite-components is in an initializer.
 ```ember g initializer calcite-components```
 
 ```js
-import {
-  applyPolyfills,
-  defineCustomElements
-} from '@esri/calcite-components/dist/loader';
+// src/initializers/calcite-components.js
+import { defineCustomElements } from "@esri/calcite-components/dist/loader";
 
-// Applying polyfills is only necessary if you support IE11/Edge
-applyPolyfills().then(() => {
-  // define calcite components' custom elements on the window
-  // define the resourcesUrl as well
-  defineCustomElements(window, {
-    resourcesUrl: "assets/calcite/"
-  });
-
+defineCustomElements(window, {
+  resourcesUrl: "assets/calcite/",
 });
 
 export function initialize() {}
 
 export default {
-  initialize
+  initialize,
 };
+
 ```
 
 This is basically a no-op initializer from an ember point of view. However, it allows:

--- a/preact-typescript/README.md
+++ b/preact-typescript/README.md
@@ -19,16 +19,13 @@ To install calcite components, first run:
 npm install --save @esri/calcite-components
 ```
 
-After calcite-components is installed, import the loader in your `index.js` file:
+After calcite-components is installed, import the loader and define the custom elements:
 
 ```js
-import { applyPolyfills, defineCustomElements } from '@esri/calcite-components/dist/loader';
+// src/index.js
+import { defineCustomElements } from '@esri/calcite-components/dist/loader';
 
-// Apply polyfills and then define the custom elements
-// polyfills are not needed if you don't support IE11 or Edge
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ## Adding the CSS

--- a/react/README.md
+++ b/react/README.md
@@ -19,35 +19,21 @@ You will also see any lint errors in the console.
 To install calcite components, first run:
 
 ```
-npm install --save @esri/calcite-components @esri/calcite-components-react
+npm install --save @esri/calcite-components-react
 ```
 
-After calcite-components is installed, import the set up the loader in your `index.js` file:
+After calcite-components is installed, import the components you will use in the app as well as the global CSS:
 
 ```
-import { applyPolyfills, defineCustomElements } from '@esri/calcite-components/dist/loader';
-
-// Apply polyfills and then define the custom elements
-// polyfills are not needed if you don't support IE11 or Edge
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
-```
-
-## Adding the CSS
-
-The global calcite components CSS can be added by importing it into your `src/App.js` file:
-
-```
-import '@esri/calcite-components/dist/calcite/calcite.css';
-```
-
-## Adding the components
-
-Then import any components you'd like to use:
-
-```
-import { CalciteAvatar, CalciteButton, CalciteIcon, CalciteSlider } from "@esri/calcite-components-react";
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-slider";
+import {
+  CalciteButton,
+  CalciteIcon,
+  CalciteSlider
+} from "@esri/calcite-components-react";
+import "@esri/calcite-components/dist/calcite/calcite.css";
 ```
 
 ## Adding the assets
@@ -59,7 +45,6 @@ npm run copy
 ```
 
 This will copy the JSON assets required by the icon component to your project's `public/assets` directory.
-
 
 ## Why not just use the web components directly?
 

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -19,27 +19,21 @@ To install calcite components, first run:
 npm install --save @esri/calcite-components
 ```
 
-After calcite-components is installed, import the custom elements bundle and the global CSS in your `main.js` file:
+After calcite-components is installed, import the components you will use in the app as well as the global CSS:
 
 ```js
+// src/main.js
+import { setAssetPath } from '@esri/calcite-components/dist/components';
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-date-picker";
 import '@esri/calcite-components/dist/calcite/calcite.css';
-import { defineCustomElements, setAssetPath } from '@esri/calcite-components/dist/custom-elements';
 
 setAssetPath(document.currentScript.src);
-defineCustomElements();
+
 ```
 
 Using `setAssetPath` will ensure that calcite components look for assets like icons in the correct location (more on copying assets below).
-
-Notice in the above code sample we aren't passing any arguments to `defineCustomElements`. This will define all of the available components. You can also import just what you need by selecting individual icons:
-
-```js
-import { CalciteButton } from '@esri/calcite-components/dist/custom-elements';
-
-customElements.define('calcite-button', CalciteButton);
-```
-
-See Stencil's [custom elements documentation](https://stenciljs.com/docs/custom-elements) for more information.
 
 ## Configuring Rollup
 

--- a/vite/README.md
+++ b/vite/README.md
@@ -19,27 +19,20 @@ To install calcite components, first run:
 npm install --save @esri/calcite-components
 ```
 
-After calcite-components is installed, import the custom elements bundle and the global CSS in your `main.js` file:
+After calcite-components is installed, import the components you will use in the app as well as the global CSS:
 
 ```js
-import '@esri/calcite-components/dist/calcite/calcite.css';
-import { defineCustomElements, setAssetPath } from '@esri/calcite-components/dist/custom-elements';
+// main.js
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-date-picker";
+import "@esri/calcite-components/dist/calcite/calcite.css";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
 
 setAssetPath(location.href);
-defineCustomElements();
 ```
 
 Using `setAssetPath` will ensure that calcite components look for assets like icons in the correct location (more on copying assets below).
-
-Notice in the above code sample we aren't passing any arguments to `defineCustomElements`. This will define all of the available components. You can also import just what you need by selecting individual icons:
-
-```js
-import { CalciteButton } from '@esri/calcite-components/dist/custom-elements';
-
-customElements.define('calcite-button', CalciteButton);
-```
-
-See Stencil's [custom elements documentation](https://stenciljs.com/docs/custom-elements) for more information.
 
 ## Configuring Vite
 

--- a/vue/README.md
+++ b/vue/README.md
@@ -18,23 +18,24 @@ To install calcite components, first run:
 npm install --save @esri/calcite-components
 ```
 
-After calcite-components is installed, import the set up the loader in your `src/main.js` file:
+After calcite-components is installed, import and call `setAssetPath` and configure the vue app:
 
-```ts
-import { applyPolyfills, defineCustomElements } from "@esri/calcite-components/dist/loader";
-
-// Apply polyfills and then define the custom elements
-// polyfills are not needed if you don't support IE11 or Edge
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+```js
+// src/main.js
+import { setAssetPath } from "@esri/calcite-components/dist/components";
+setAssetPath(location.href);
 
 // tell Vue.js to ignore Calcite Components
 Vue.config.ignoredElements = [/calcite-\w*/];
+Vue.config.productionTip = false;
+```
 
-new Vue({
-  render: h => h(App)
-}).$mount("#app");
+Import the calcite components when they are used:
+```js
+// src/components/HellowWorld.vue
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-date-picker";
 ```
 
 ## Adding the CSS

--- a/webpack/README.md
+++ b/webpack/README.md
@@ -23,14 +23,19 @@ To install calcite components, first run:
 npm install --save @esri/calcite-components
 ```
 
-After calcite-components is installed, import the loader in your `src/index.js` file:
+After calcite-components is installed, import the components you will use in the app:
 
 ```js
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from "@esri/calcite-components/dist/loader";
+// src/index.js
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-date-picker";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
+
+setAssetPath(location.href);
 ```
+
+Using `setAssetPath` will ensure that calcite components look for assets like icons in the correct location (more on copying assets below).
 
 ## Adding the CSS
 


### PR DESCRIPTION
- removes instructions on setting up polyfills since we no longer support it
- updates the readmes to use the `dist/components` build