### PR TITLE
docs(ember): adding additional instructions for setting the correct node version and start command

### DIFF
--- a/ember/README.md
+++ b/ember/README.md
@@ -4,7 +4,14 @@ This is an example of how to use [@esri/calcite-components](https://github.com/E
 
 ## Running the Application
 
-First, install dependencies:
+First, ensure you are using Node 14:
+
+```
+nvm install 14
+nvm use 14
+```
+
+Second, install dependencies:
 
 ```
 npm install
@@ -13,7 +20,7 @@ npm install
 After that, start up a dev server with:
 
 ```
-ember serve
+npm start
 ```
 
 This will run the app in the development mode. Open [http://localhost:4200](http://localhost:4200) to view it in the browser.


### PR DESCRIPTION
Had some difficulty getting this to run at first since I'm on Node 16 and for this version of Ember I had to switch to Node 14.  I also noticed that `ember serve` wasn't available for me, which I assume is because I need to globally install `ember-cli` but since there's already a `start` script that calls that command, I figured it makes sense to change the docs to say use `npm start` instead.