### PR TITLE
feat(vue3): adding an event directive to demonstrate how to listen to calcite custom events in a vue3 template

### DIFF
--- a/vue/vue3/README.md
+++ b/vue/vue3/README.md
@@ -76,3 +76,7 @@ module.exports = {
 ```
 
 Check out Vue's [web components documentation](https://v3.vuejs.org/guide/web-components.html) for more information.
+
+## Known Issues
+
+Vue 3 currently doesn't support attaching event listeners on a custom element in a template to a custom event that contains capital letters: [https://github.com/vuejs/core/issues/5401](vuejs/core#5401).  To workaround this, adding a Vue directive will allow your Vue component to listen for custom events emitted from Calcite components.  See the `src/components/HelloWorld.vue` file for an example on this approach.

--- a/vue/vue3/src/components/HelloWorld.vue
+++ b/vue/vue3/src/components/HelloWorld.vue
@@ -1,22 +1,52 @@
-<template>
-  <div class="hello">
-    <h1>{{ msg }} <calcite-icon icon="banana"></calcite-icon></h1>
-    <calcite-date-picker></calcite-date-picker>
-    <calcite-button>Button</calcite-button>
-  </div>
-</template>
-
 <script>
 import '@esri/calcite-components/dist/components/calcite-button';
 import '@esri/calcite-components/dist/components/calcite-date-picker';
 import '@esri/calcite-components/dist/components/calcite-icon';
+
+/**
+ * This is a workaround for listening to custom events
+ * that contain capital letters.  Adapted from:
+ * https://github.com/vuejs/core/issues/5401#issuecomment-1041214293
+ */
+const eventDirective = {
+  beforeMount(el, { arg, value }) {
+    console.log(arg); // casing is preserved, check console
+    el.addEventListener(arg, value);
+  },
+  beforeUnmount(el, { arg, value }) {
+    el.removeEventListener(arg, value);
+  },
+};
 
 export default {
   name: 'HelloWorld',
   props: {
     msg: String,
   },
+  methods: {
+    datePickerRangeChangeHandler(event) {
+      console.log(
+        'datePickerRangeChangeHandler',
+        event.detail,
+      );
+    },
+  },
+  directives: {
+    event: eventDirective,
+  },
 };
 </script>
 
 <style src="@esri/calcite-components/dist/calcite/calcite.css"></style>
+
+<template>
+  <div class="hello">
+    <h1>{{ msg }} <calcite-icon icon="banana"></calcite-icon>
+    </h1>
+    <calcite-date-picker
+      range
+      v-event:calciteDatePickerRangeChange="datePickerRangeChangeHandler"
+    ></calcite-date-picker>
+    <calcite-button>Button</calcite-button>
+  </div>
+</template>


### PR DESCRIPTION
Related issue: https://community.esri.com/t5/calcite-design-system-questions/event-handler-directive-not-support-for-components/m-p/1214690#M229

This PR adds a custom directive to the HelloWorld example component in Vue3 to allow adding declarative support for custom event handlers in a Vue3 template.

Vue3 currently doesn't support attaching event listeners on a custom element in a template to a custom event that contains capital letters, which virtually all calcite custom events have.  https://github.com/vuejs/core/issues/5401