### PR TITLE
feat(vite): add calcite dist output target sample

### DIFF
--- a/vite/calcite-dist-build.js
+++ b/vite/calcite-dist-build.js
@@ -1,0 +1,4 @@
+import { defineCustomElements } from "@esri/calcite-components/dist/loader";
+defineCustomElements(window);
+
+import "@esri/calcite-components/dist/calcite/calcite.css";

--- a/vite/index.html
+++ b/vite/index.html
@@ -8,8 +8,8 @@
   </head>
   <body>
     <calcite-button>My Button</calcite-button>
-		<calcite-date-picker range></calcite-date-picker>
-		<calcite-input></calcite-input>
+    <calcite-date-picker range></calcite-date-picker>
+    <calcite-input></calcite-input>
     <calcite-icon icon="banana"></calcite-icon>
 
     <script type="module" src="/main.js"></script>

--- a/vite/index.html
+++ b/vite/index.html
@@ -12,11 +12,12 @@
     <calcite-input></calcite-input>
     <calcite-icon icon="banana"></calcite-icon>
 
+    <!-- If using the distribution build, comment out the "main.js" file -->
     <script type="module" src="/main.js"></script>
 
     <!--
-      Replace main.js with the script below to use Vite with auto-lazy-loaded Calcite Components
-      @link https://stenciljs.com/docs/distribution
+      If using the distribution build, load the "calcite-dist-build.js" file to use Vite with auto-lazy loaded Calcite Components.
+      @link https://developers.arcgis.com/calcite-design-system/get-started/#distribution
     -->
     <!-- <script type="module" src="/calcite-dist-build.js"></script> -->
   </body>

--- a/vite/index.html
+++ b/vite/index.html
@@ -8,7 +8,16 @@
   </head>
   <body>
     <calcite-button>My Button</calcite-button>
+		<calcite-date-picker range></calcite-date-picker>
+		<calcite-input></calcite-input>
     <calcite-icon icon="banana"></calcite-icon>
+
     <script type="module" src="/main.js"></script>
+
+    <!--
+      Replace main.js with the script below to use Vite with auto-lazy-loaded Calcite Components
+      @link https://stenciljs.com/docs/distribution
+    -->
+    <!-- <script type="module" src="/calcite-dist-build.js"></script> -->
   </body>
 </html>


### PR DESCRIPTION
Related Issue: https://github.com/Esri/calcite-components/pull/6452

This adds the `dist` output target sample code to the vite example for posterity.