### PR TITLE
feat(angular): add ng concepts

### DIFF
--- a/angular/src/app/app.component.html
+++ b/angular/src/app/app.component.html
@@ -1,3 +1,5 @@
-<h1>Hello Angular! <calcite-icon icon="banana"></calcite-icon></h1>
-<calcite-date-picker></calcite-date-picker>
-<calcite-button>My Button</calcite-button>
+<h1>Hello {{title}}! <calcite-icon icon="banana"></calcite-icon></h1>
+
+<calcite-combobox placeholder="Select a field" label="Select a field" (calciteComboboxChange)="logSelectedFields($event)">
+  <calcite-combobox-item *ngFor="let field of fields"  [value]="field.value" [textLabel]="field.displayText"></calcite-combobox-item>
+</calcite-combobox>

--- a/angular/src/app/app.component.html
+++ b/angular/src/app/app.component.html
@@ -1,5 +1,5 @@
 <h1>Hello {{title}}! <calcite-icon icon="banana"></calcite-icon></h1>
 
 <calcite-combobox placeholder="Select a field" label="Select a field" (calciteComboboxChange)="logSelectedFields($event)">
-  <calcite-combobox-item *ngFor="let field of fields"  [value]="field.value" [textLabel]="field.displayText"></calcite-combobox-item>
+  <calcite-combobox-item *ngFor="let field of fields" [value]="field.value" [textLabel]="field.displayText"></calcite-combobox-item>
 </calcite-combobox>

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 
 // Calcite Components
-import '@esri/calcite-components/dist/components/calcite-button';
 import '@esri/calcite-components/dist/components/calcite-icon';
-import '@esri/calcite-components/dist/components/calcite-date-picker';
+import '@esri/calcite-components/dist/components/calcite-combobox';
+import '@esri/calcite-components/dist/components/calcite-combobox-item';
+
 
 @Component({
   selector: 'app-root',
@@ -11,5 +12,46 @@ import '@esri/calcite-components/dist/components/calcite-date-picker';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  title = 'angular';
+  title: string = "Angular";
+
+  fields = [
+    {
+      "displayText": "Natural Resources",
+      "value": "natural-resources"
+    },
+    {
+      "displayText": "Agriculture",
+      "value": "agriculture"
+    },
+    {
+      "displayText": "Forestry",
+      "value": "forestry"
+    },
+    {
+      "displayText": "Mining",
+      "value": "mining"
+    },
+    {
+      "displayText": "Business",
+      "value": "business"
+    },
+    {
+      "displayText": "Education",
+      "value": "education"
+    },
+    {
+      "displayText": "Utilities",
+      "value": "utilities"
+    },
+    {
+      "displayText": "Transportation",
+      "value": "transportation"
+    }
+  ];
+
+  logSelectedFields(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    console.log(value);
+  }
+
 }


### PR DESCRIPTION
We've been getting a few Angular-specific questions lately and thinking we could enhance some of our examples to include:
- An event example e.g., `calciteComboboxChange`
- A `*ngFor` example, and
- TypeScript typings 

Leverages our [component sample](https://developers.arcgis.com/calcite-design-system/components/combobox/#sample) with the `calciteComboboxChange` event, adding the component's value to the console.

