### PR TITLE
docs(react): simplify usage instructions and demo introduced in @esri/calcite-components@1.5.0

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -27,7 +27,7 @@ This package includes the compatible version of the main component library as a 
 
 ## Use
 
-[Custom Elements](https://stenciljs.com/docs/custom-elements) is the recomended build when using frontend frameworks, such as React. To use this build, you will need to set the path to the `calcite-components` assets. You can either use local assets, which will be explained in a subsequent step, or assets hosted on a CDN. This example uses local assets.
+[Custom Elements](https://stenciljs.com/docs/custom-elements) is the recommended build when using frontend frameworks, such as React. To use this build, you will need to set the path to the `calcite-components` assets. You can either use local assets, which will be explained in a subsequent step, or assets hosted on a CDN. This example uses local assets.
 
 ```jsx
 import { setAssetPath } from '@esri/calcite-components/dist/components';
@@ -38,12 +38,9 @@ setAssetPath(window.location.href);
 // setAssetPath("https://unpkg.com/@esri/calcite-components/dist/calcite/assets");
 ```
 
-Next, you need to import each component you use from the standard `calcite-component` package's build. This will automatically define the custom elements on the window. Then import the same components from `calcite-components-react`.
+Next, you need to import each component you use from `calcite-components-react`. This will automatically define the custom elements on the browser.
 
 ```jsx
-import '@esri/calcite-components/dist/components/calcite-button';
-import '@esri/calcite-components/dist/components/calcite-icon';
-import '@esri/calcite-components/dist/components/calcite-slider';
 import {
   CalciteButton,
   CalciteIcon,

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@esri/calcite-components-react": "^1.4.3",
+        "@esri/calcite-components-react": "^1.5.0-next.25",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -1916,28 +1916,28 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.3.tgz",
-      "integrity": "sha512-3Yj0ZBOPBCIEp+YPJTM0C6cBmbxFXXsG9a6yv0DKxkaERj7te+hb3DQ1fVbG/lQsMLOdrQHiE70zdXSzMKvKCg==",
+      "version": "1.5.0-next.25",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0-next.25.tgz",
+      "integrity": "sha512-OVOboSITChMsHoPlP8qUqObqelxtR/x6bujYFYYtAlNODk5zay9A86MdOrDDjmBSg33DdhJuJmhLoSRg/JMIqA==",
       "dependencies": {
-        "@floating-ui/dom": "1.4.1",
+        "@floating-ui/dom": "1.4.5",
         "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.8",
-        "focus-trap": "7.4.3",
+        "dayjs": "1.11.9",
+        "focus-trap": "7.5.2",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
       }
     },
     "node_modules/@esri/calcite-components-react": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.4.3.tgz",
-      "integrity": "sha512-jLRgk0T/AC04gia/zNe2h2svPvyQtmN0QWJt6D4xqODuaXM+W3UTP6xCq7Z1vrUb+gCQXLTbW8oInKL/YfXGmw==",
+      "version": "1.5.0-next.25",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0-next.25.tgz",
+      "integrity": "sha512-yan9+nNv4CaPgZQPPBe3FO8kBTFImaT6hoRCdEhM1OW7ItRFfLC+ufOYRiZZwsoJALY7IUnZoRbSC9hsifKvrA==",
       "dependencies": {
-        "@esri/calcite-components": "1.4.3"
+        "@esri/calcite-components": "^1.5.0-next.25"
       },
       "peerDependencies": {
         "react": ">=16.7",
@@ -1950,9 +1950,9 @@
       "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.1.tgz",
-      "integrity": "sha512-loCXUOLzIC3jp50RFOKXZ/kQjjz26ryr/23M+FWG9jrmAv8lRf3DUfC2AiVZ3+K316GOhB08CR+Povwz8e9mDw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
+      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
       "dependencies": {
         "@floating-ui/core": "^1.3.1"
       }
@@ -5874,9 +5874,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
-      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -7513,11 +7513,11 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "node_modules/focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "dependencies": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -17455,28 +17455,28 @@
       }
     },
     "@esri/calcite-components": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.3.tgz",
-      "integrity": "sha512-3Yj0ZBOPBCIEp+YPJTM0C6cBmbxFXXsG9a6yv0DKxkaERj7te+hb3DQ1fVbG/lQsMLOdrQHiE70zdXSzMKvKCg==",
+      "version": "1.5.0-next.25",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0-next.25.tgz",
+      "integrity": "sha512-OVOboSITChMsHoPlP8qUqObqelxtR/x6bujYFYYtAlNODk5zay9A86MdOrDDjmBSg33DdhJuJmhLoSRg/JMIqA==",
       "requires": {
-        "@floating-ui/dom": "1.4.1",
+        "@floating-ui/dom": "1.4.5",
         "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.8",
-        "focus-trap": "7.4.3",
+        "dayjs": "1.11.9",
+        "focus-trap": "7.5.2",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
       }
     },
     "@esri/calcite-components-react": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.4.3.tgz",
-      "integrity": "sha512-jLRgk0T/AC04gia/zNe2h2svPvyQtmN0QWJt6D4xqODuaXM+W3UTP6xCq7Z1vrUb+gCQXLTbW8oInKL/YfXGmw==",
+      "version": "1.5.0-next.25",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0-next.25.tgz",
+      "integrity": "sha512-yan9+nNv4CaPgZQPPBe3FO8kBTFImaT6hoRCdEhM1OW7ItRFfLC+ufOYRiZZwsoJALY7IUnZoRbSC9hsifKvrA==",
       "requires": {
-        "@esri/calcite-components": "1.4.3"
+        "@esri/calcite-components": "^1.5.0-next.25"
       }
     },
     "@floating-ui/core": {
@@ -17485,9 +17485,9 @@
       "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
     },
     "@floating-ui/dom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.1.tgz",
-      "integrity": "sha512-loCXUOLzIC3jp50RFOKXZ/kQjjz26ryr/23M+FWG9jrmAv8lRf3DUfC2AiVZ3+K316GOhB08CR+Povwz8e9mDw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
+      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
       "requires": {
         "@floating-ui/core": "^1.3.1"
       }
@@ -20385,9 +20385,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
-      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
     },
     "debug": {
       "version": "4.3.3",
@@ -21603,11 +21603,11 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "focus-trap": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "requires": {
-        "tabbable": "^6.1.2"
+        "tabbable": "^6.2.0"
       }
     },
     "follow-redirects": {

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@esri/calcite-components-react": "^1.5.0-next.25",
+        "@esri/calcite-components-react": "^1.5.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -1916,11 +1916,11 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.5.0-next.25",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0-next.25.tgz",
-      "integrity": "sha512-OVOboSITChMsHoPlP8qUqObqelxtR/x6bujYFYYtAlNODk5zay9A86MdOrDDjmBSg33DdhJuJmhLoSRg/JMIqA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0.tgz",
+      "integrity": "sha512-0HJhHI9p/6IPewIVKimg31o6/pbPJid3Q23m87dbDIjBDS3HxxNQD+EbfZndYHe/HC3KbJ9WSaEd0JA56Ux9Lw==",
       "dependencies": {
-        "@floating-ui/dom": "1.4.5",
+        "@floating-ui/dom": "1.5.1",
         "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
@@ -1933,11 +1933,11 @@
       }
     },
     "node_modules/@esri/calcite-components-react": {
-      "version": "1.5.0-next.25",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0-next.25.tgz",
-      "integrity": "sha512-yan9+nNv4CaPgZQPPBe3FO8kBTFImaT6hoRCdEhM1OW7ItRFfLC+ufOYRiZZwsoJALY7IUnZoRbSC9hsifKvrA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0.tgz",
+      "integrity": "sha512-fBfMTdO4sc59F7+1JdLS462ucB54dtAKyWYAO85FNZkOVJMScwDsgtNhzlUlxUhcQyMz2+VgKTz2XOgqyehmsw==",
       "dependencies": {
-        "@esri/calcite-components": "^1.5.0-next.25"
+        "@esri/calcite-components": "^1.5.0"
       },
       "peerDependencies": {
         "react": ">=16.7",
@@ -1945,17 +1945,26 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.1"
+      }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
-      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+      "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
       "dependencies": {
-        "@floating-ui/core": "^1.3.1"
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
       }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.3",
@@ -17455,11 +17464,11 @@
       }
     },
     "@esri/calcite-components": {
-      "version": "1.5.0-next.25",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0-next.25.tgz",
-      "integrity": "sha512-OVOboSITChMsHoPlP8qUqObqelxtR/x6bujYFYYtAlNODk5zay9A86MdOrDDjmBSg33DdhJuJmhLoSRg/JMIqA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.5.0.tgz",
+      "integrity": "sha512-0HJhHI9p/6IPewIVKimg31o6/pbPJid3Q23m87dbDIjBDS3HxxNQD+EbfZndYHe/HC3KbJ9WSaEd0JA56Ux9Lw==",
       "requires": {
-        "@floating-ui/dom": "1.4.5",
+        "@floating-ui/dom": "1.5.1",
         "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
@@ -17472,25 +17481,34 @@
       }
     },
     "@esri/calcite-components-react": {
-      "version": "1.5.0-next.25",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0-next.25.tgz",
-      "integrity": "sha512-yan9+nNv4CaPgZQPPBe3FO8kBTFImaT6hoRCdEhM1OW7ItRFfLC+ufOYRiZZwsoJALY7IUnZoRbSC9hsifKvrA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-1.5.0.tgz",
+      "integrity": "sha512-fBfMTdO4sc59F7+1JdLS462ucB54dtAKyWYAO85FNZkOVJMScwDsgtNhzlUlxUhcQyMz2+VgKTz2XOgqyehmsw==",
       "requires": {
-        "@esri/calcite-components": "^1.5.0-next.25"
+        "@esri/calcite-components": "^1.5.0"
       }
     },
     "@floating-ui/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.1"
+      }
     },
     "@floating-ui/dom": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
-      "integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+      "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
       "requires": {
-        "@floating-ui/core": "^1.3.1"
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
       }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@esri/calcite-components-react": "^1.5.0-next.25",
+    "@esri/calcite-components-react": "^1.5.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@esri/calcite-components-react": "^1.4.3",
+    "@esri/calcite-components-react": "^1.5.0-next.25",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -1,7 +1,4 @@
 import React, { useState } from 'react';
-import '@esri/calcite-components/dist/components/calcite-button';
-import '@esri/calcite-components/dist/components/calcite-icon';
-import '@esri/calcite-components/dist/components/calcite-slider';
 import {
   CalciteButton,
   CalciteIcon,


### PR DESCRIPTION
1.5.0 simplifies component imports in React and this updates the example/doc accordingly.

This also includes some minor doc tweaks.