### PR TITLE
fix typo in calciteAssetsTree Funnel definition

### DIFF
--- a/ember/README.md
+++ b/ember/README.md
@@ -129,7 +129,7 @@ module.exports = function (defaults) {
     './node_modules/@esri/calcite-components/dist',
     {
       srcDir: '/',
-      include: ['calcite/assets/*/*'],
+      include: ['calcite/assets/**/*'],
       destDir: '/assets',
     }
   );


### PR DESCRIPTION
The "include" option's path is missing an asterisk in the directory wildcard spot. Following this instruction as-is results in errors. I just added the missing asterisk.