### PR TITLE
fix(react): add back CC imports due to potential stencil bug

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -1,4 +1,7 @@
 import React, { useState } from 'react';
+import "@esri/calcite-components/dist/components/calcite-button.js";
+import "@esri/calcite-components/dist/components/calcite-icon.js";
+import "@esri/calcite-components/dist/components/calcite-slider.js";
 import {
   CalciteButton,
   CalciteIcon,


### PR DESCRIPTION
There is an issue with auto-importing and defining calcite components using the react wrapper via https://github.com/Esri/calcite-design-system/pull/7185

It appears to be a Stencil bug related to our SSR patch which dynamically imports the web components to prevent them from rendering on the server.
https://github.com/Esri/calcite-design-system/pull/7521