### PR TITLE
chore: configure repo issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Calcite Design System repository
+    url: https://github.com/Esri/calcite-design-system/issues/new/choose
+    about: Report bugs or request enhancements in the Calcite Design System GitHub repo.
+  - name: Esri Support
+    url: https://support.esri.com/en/contact-tech-support
+    about: Report bugs in released versions of Calcite Design System, and request enhancements.
+  - name: Esri Community
+    url: https://community.esri.com/t5/calcite-design-system/ct-p/calcite-design-system
+    about: Ask questions, share ideas, and collaborate with others on Calcite Design System.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calcite Components Examples
 
-Working example applications utilizing [calcite-components](https://github.com/Esri/calcite-components). Each folder within this repository is its own mini application demonstrating integration of Calcite Components with other technologies and tooling.
+Working example applications utilizing [Calcite Design System](https://github.com/Esri/calcite-design-system). Each folder within this repository is its own mini application demonstrating integration of Calcite Components with other technologies and tooling.
 
 Most frameworks provide a CLI tool to quickly start up a repo. If available, these tools are used to create the examples to ensure they are colloquial to the framework in question. After a starter project is scaffolded up, calcite-components are installed and some general steps are taken:
 
@@ -9,6 +9,12 @@ Most frameworks provide a CLI tool to quickly start up a repo. If available, the
 3. Ensure Calcite Components' assets get copied into the project (allows the `calcite-icon` component to work)
 
 This repository will change over time as new best-practices are established and framework integrations are improved.
+
+**Troubleshooting**
+
+To troubleshoot an error or issue with the examples, please visit [Esri Support](https://support.esri.com/en/contact-tech-support), or visit [Calcite's Community](https://community.esri.com/t5/calcite-design-system/ct-p/calcite-design-system) to ask questions, share ideas, and collaborate with other community members on Calcite Design System.
+
+To report bugs or request enhancements, navigate to [Calcite Design System's GitHub repository](https://github.com/Esri/calcite-design-system/issues/new/choose).
 
 ## Angular
 


### PR DESCRIPTION
Removes custom issues and directs folks to the Calcite Design System repo, Esri Support, and Esri Community.

![image](https://github.com/Esri/calcite-components-examples/assets/5023024/70ce3087-f856-4052-aee1-7d2ede6eb626)


Also updates the README file with the updated Calcite repo name, link, and with a troubleshooting section detailing the above resources as well.


