### PR TITLE
docs: add intellisense setup info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ npx degit "rollup/rollup-starter-app" [NAME]
 
 The [Webpack example](./webpack/) was built from scratch using Webpack 4.x.
 
+## Visual Studio IntelliSense
+
+Calcite supports IntelliSense in Visual Studio Code. You can quickly add components and their attributes or properties while writing your app. There is also accompanying documentation to help you along the way.
+
+![Calcite IntelliSense in Visual Studio Code](https://user-images.githubusercontent.com/5023024/213829317-32f534fd-6f37-4c10-aa24-f402056ef939.gif)
+
+To setup IntelliSense, add the following to the `.vscode/settings.json` file in your project:
+
+```json
+  "html.customData": [
+    "./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"
+  ]
+```
+
 ## License
 
 COPYRIGHT © 2023 Esri

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The [Webpack example](./webpack/) was built from scratch using Webpack 4.x.
 
 ## Visual Studio IntelliSense
 
-Calcite supports IntelliSense in Visual Studio Code. You can quickly add components and their attributes or properties while writing your app. There is also accompanying documentation to help you along the way.
+Calcite supports IntelliSense in Visual Studio Code. You can quickly add components and their attributes or properties in the Visual Studio Code editor, where accompanying documentation will help you along the way.
 
 ![Calcite IntelliSense in Visual Studio Code](https://user-images.githubusercontent.com/5023024/213829317-32f534fd-6f37-4c10-aa24-f402056ef939.gif)
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ To setup IntelliSense, add the following to the `.vscode/settings.json` file in 
   ]
 ```
 
+For more detailed information on IntelliSense, visit the [Visual Studio Code IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) documentation.
+
 ## License
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 


### PR DESCRIPTION
Feedback requested having this information in a more visible location. So in addition to adding the VSCode IntelliSense setup info from January 2023 summary into the "Framework Integration" doc site page, we think it makes sense to also include that information in examples repo readme.